### PR TITLE
Invert post validators

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,8 +46,7 @@ Default: ``[]``
 
    modeling_models = [Story, Spec]
 
-See `here <https://github.com/useblocks/sphinx-modeling/blob/main/tests/doc_test/doc_modeling/conf.py>`_
-for a full example.
+The repository contains a `full example <https://github.com/useblocks/sphinx-modeling/blob/main/tests/doc_test/doc_modeling/conf.py>`_. More examples and details can be found in the :ref:`modeling_guidelines`.
 
 .. _modeling_remove_fields:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,6 +19,7 @@ Options
 
 All configuration options starts with the prefix ``modeling_`` for Sphinx-Modeling.
 
+.. _modeling_models:
 
 modeling_models
 ~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Generation of the following ``Sphinx-Needs`` configurations from a model configu
 
    installation
    configuration
+   modeling
    contributing
    support
    changelog

--- a/docs/modeling.rst
+++ b/docs/modeling.rst
@@ -1,0 +1,77 @@
+.. _modeling_guidelines:
+
+Modeling guidelines
+===================
+
+Validators
+----------
+
+.. warning::
+    The currently used Pydantic version may raise an exception when custom validators:
+
+    .. code-block:: text
+
+          File "pydantic/class_validators.py", line 145, in pydantic.class_validators._prepare_validator
+        TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+
+    The affected code uses ``__func__.__module__``. The ``__module__`` class variable is not guaranteed to be defined.
+    A workaround is to set the `allow_reuse <https://pydantic-docs.helpmanual.io/usage/validators/#reuse-validators>`_ flag to ``True`` like shown in the examples below.
+
+Context variables
+-----------------
+
+User defined `root validators <https://pydantic-docs.helpmanual.io/usage/validators/#root-validators>`_ have access to the following variables in ``values``:
+
+- ``all_needs`` the needs dictionary
+- ``env`` the Sphinx environment
+
+Pydantic v1 does not offer context variables, so
+`this workaround <https://github.com/pydantic/pydantic/issues/1170#issuecomment-575233689>`_ is used.
+The feature is however planned for pydantic v2 (see `here <https://github.com/pydantic/pydantic/issues/1549>`__ and
+`here <https://pydantic-docs.helpmanual.io/blog/pydantic-v2/#validation-context>`__).
+
+Validate linked need
+--------------------
+
+This model checks whether linked stories have the right value in their ``active`` field:
+
+.. code-block:: python
+
+    class Story(BaseModelNeeds, extra=Extra.forbid):
+        id: str
+        type: Literal["story"]
+        active: Literal["True", "False"]
+
+
+    class Spec(BaseModelNeeds, extra=Extra.forbid):
+        id: str
+        type: Literal["spec"]
+        links: conlist(Story, min_items=1, max_items=1)
+
+        @validator("links", allow_reuse=True)
+        def linked_story_active(value):
+            if value[0].active == "False":
+                raise ValueError("Can only link active stories")
+            return value
+
+This RST
+
+.. code-block:: rst
+
+    .. story:: Test story 1
+       :id: US_001
+       :active: False
+
+    .. spec:: Test spec1
+       :id: SP_001
+       :links: US_001
+
+leads to the warnings:
+
+.. code-block:: text
+
+    WARNING: Model validation: failed for need SP_001
+    WARNING: 1 validation error for Spec
+    links
+      Can only link active stories (type=value_error)    
+

--- a/docs/modeling.rst
+++ b/docs/modeling.rst
@@ -7,7 +7,7 @@ Validators
 ----------
 
 .. warning::
-    The currently used Pydantic version may raise an exception when custom validators:
+    The currently used Pydantic version may raise an exception for custom validators:
 
     .. code-block:: text
 

--- a/docs/modeling.rst
+++ b/docs/modeling.rst
@@ -25,9 +25,9 @@ User defined `root validators <https://pydantic-docs.helpmanual.io/usage/validat
 - ``all_needs`` the needs dictionary
 - ``env`` the Sphinx environment
 
-Pydantic v1 does not offer context variables, so
+Pydantic v1 does not yet offer context variables, so
 `this workaround <https://github.com/pydantic/pydantic/issues/1170#issuecomment-575233689>`_ is used.
-The feature is however planned for pydantic v2 (see `here <https://github.com/pydantic/pydantic/issues/1549>`__ and
+The feature is however planned for Pydantic v2 (see `here <https://github.com/pydantic/pydantic/issues/1549>`__ and
 `here <https://pydantic-docs.helpmanual.io/blog/pydantic-v2/#validation-context>`__).
 
 Validate linked need

--- a/docs/modeling.rst
+++ b/docs/modeling.rst
@@ -3,8 +3,44 @@
 Modeling guidelines
 ===================
 
-Validators
+Model names
+-----------
+
+The validation logic passes each need object to Pydantic. The need type is used to look up the correct model in
+the configuration list :ref:`modeling_models`.
+Therefore each user provided Pydantic class name must conform to the pattern ``need['type'].title()``.
+A need type called ``spec`` results in a class name ``Spec``. A type ``CustomSpec`` would result in ``Customspec``.
+
+Base class
 ----------
+
+Each user provided Pydantic model must inherit from ``BaseModelNeeds``.
+
+Need link resolution
+--------------------
+
+The base class ``BaseModelNeeds`` features a root validator of type ``pre`` that runs before any other validators.
+It ensures that linked needs will be provided as nested models, so a user model can directly define need links:
+
+.. code-block:: python
+
+    class Story(BaseModelNeeds):
+        id: str
+        type: Literal["story"]
+
+    class Spec(BaseModelNeeds):
+        id: str
+        type: Literal["spec"]
+
+    class Impl(BaseModelNeeds):
+        id: str
+        type: Literal["spec"]
+        links: conlist(Union[Story, Spec] , min_items=1, max_items=1)
+
+In above example each ``Impl`` must link to exactly one ``Story`` or ``Spec``.
+
+Custom validators
+-----------------
 
 .. warning::
     The currently used Pydantic version may raise an exception for custom validators:
@@ -29,6 +65,7 @@ Pydantic v1 does not yet offer context variables, so
 `this workaround <https://github.com/pydantic/pydantic/issues/1170#issuecomment-575233689>`_ is used.
 The feature is however planned for Pydantic v2 (see `here <https://github.com/pydantic/pydantic/issues/1549>`__ and
 `here <https://pydantic-docs.helpmanual.io/blog/pydantic-v2/#validation-context>`__).
+
 
 Validate linked need
 --------------------

--- a/sphinx_modeling/modeling/main.py
+++ b/sphinx_modeling/modeling/main.py
@@ -225,6 +225,7 @@ def check_model(env: BuildEnvironment, msg_path: str) -> None:
             for msg in messages:
                 log.warn(msg)
         except Exception as exc:
+            all_successful = False
             log.warn(f"Model validation: failed for need {need['id']}")
             log.warn(exc.__repr__())
     if all_successful:

--- a/sphinx_modeling/modeling/main.py
+++ b/sphinx_modeling/modeling/main.py
@@ -165,9 +165,12 @@ def check_model(env: BuildEnvironment, msg_path: str) -> None:
     # build a dictionay to look up user model names
     model_name_2_model = {model.__name__: model for model in pydantic_models}
 
-    # for model in pydantic_models:
-    #     # later needed for circular model handling
-    #     model.update_forward_refs()
+    for model in pydantic_models:
+        # invert the order of root validators to have
+        # context variables available in user defined root validators
+        model.__post_root_validators__.reverse()
+        # # later needed for circular model handling
+        # model.update_forward_refs()
 
     logged_types_without_model = set()  # helper to avoid duplicate log output
     all_successful = True


### PR DESCRIPTION
Fixes a bug where user root validators do not have access to the context variables `all_needs` and `env`.