### PR TITLE
Log info in red for early feedback

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,3 +1,10 @@
+{%- macro issue(nr) -%}
+`Issue #{{ nr }} <https://github.com/useblocks/sphinx-modeling/issues/{{ nr }}>`_
+{%- endmacro -%}
+{%- macro pr(nr) -%}
+`PR #{{ nr }} <https://github.com/useblocks/sphinx-modeling/pull/{{ nr }}>`_
+{%- endmacro -%}
+
 .. _changelog:
 
 Changelog
@@ -19,25 +26,19 @@ Please see all `Unreleased Changes`_ for more information.
 Added
 ~~~~~
 
-- Circular link loops
-  (`Issue #22 <https://github.com/useblocks/sphinx-modeling/issues/22>`_,
-  `PR #25 <https://github.com/useblocks/sphinx-modeling/pull/25>`_)
+- Circular link loops ({{ issue(22) }}, {{ pr(25) }})
+- Early output of warnings ({{ issue(21) }}, {{ pr(27) }})
 
 Changed
 ~~~~~~~
 
-- Add new ignore fields ``doctype``, ``arch``
-  (`Issue #23 <https://github.com/useblocks/sphinx-modeling/issues/23>`_,
-  `PR #25 <https://github.com/useblocks/sphinx-modeling/pull/25>`_)
-- Dict type for ``modeling_models``
-  (`Issue #16 <https://github.com/useblocks/sphinx-modeling/issues/16>`_,
-  `PR #26 <https://github.com/useblocks/sphinx-modeling/pull/26>`_)
+- Add new ignore fields ``doctype``, ``arch`` ({{ issue(23) }}, {{ pr(25) }})
+- Dict type for ``modeling_models`` ({{ issue(16) }}, {{ pr(26) }})
 
 Fixed
 ~~~~~
 
-- handle need types with non-identifier characters
-  (`Issue #16 <https://github.com/useblocks/sphinx-modeling/issues/16>`_, `PR #19 <https://github.com/useblocks/sphinx-modeling/pull/19>`_)
+- handle need types with non-identifier characters ({{ issue(16) }}, {{ pr(19) }})
 
 0.1.1 - 2022-09-28
 ------------------
@@ -45,7 +46,7 @@ Fixed
 Fixed
 ~~~~~
 
-- correct handling of modeling_remove_backlinks (`PR #10 <https://github.com/useblocks/sphinx-modeling/pull/10>`_)
+- correct handling of modeling_remove_backlinks ({{ pr(10) }})
 
 0.1.0 - 2022-09-27
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,3 +93,18 @@ rst_epilog = """
    <br>
 
 """
+
+
+def rstjinja(app, docname, source):
+    """Render pages as a jinja template for fancy templating goodness."""
+    # Make sure we're outputting HTML
+    if app.builder.format != "html":
+        return
+    src = source[0]
+    rendered = app.builder.templates.render_string(src, app.config.html_context)
+    source[0] = rendered
+
+
+def setup(app):
+    """Add Sphinx events."""
+    app.connect("source-read", rstjinja)

--- a/sphinx_modeling/modeling/main.py
+++ b/sphinx_modeling/modeling/main.py
@@ -147,7 +147,8 @@ def check_model(env: BuildEnvironment, msg_path: str) -> None:
 
     if all_messages:
         for msg in all_messages:
-            log.warning(msg)
+            log.info(msg, color="red")
+        log.warning("Validation errors appeared!")
         dir_name = os.path.dirname(os.path.abspath(msg_path))
         if not os.path.exists(dir_name):
             os.makedirs(dir_name)


### PR DESCRIPTION
Short-term solution to this is:
- log validation messages with level `info` and set the color to red; it will be flushed immediately (to stdout)
- log a validation error message if any validation error appeared to maintain exit code handling for `sphinx-build -W`

The long term solution would be a Sphinx addition to state for each log message to flush it immediately in the `pending_warnings` context.